### PR TITLE
Feat : Queue 동적 스케줄링

### DIFF
--- a/gateway/src/main/java/com/j1p3ter/gateway/infrastructure/config/GatewayConfig.java
+++ b/gateway/src/main/java/com/j1p3ter/gateway/infrastructure/config/GatewayConfig.java
@@ -53,7 +53,7 @@ public class GatewayConfig {
                         .uri("lb://order-server")
                 )
                 .route("queue-server", route -> route
-                        .path("/api/waitingQueue/**", "/api/waitingRoom/**")
+                        .path("/api/waitingQueue/**", "/api/waitingRoom/**", "/api/schedulingQueue/**")
                         .filters(filter -> filter
                                 .filter((exchange, chain) -> jwtAuthorizationFilter
                                         .filter(exchange, chain)

--- a/gateway/src/main/java/com/j1p3ter/gateway/infrastructure/jwt/JwtAuthorizationFilter.java
+++ b/gateway/src/main/java/com/j1p3ter/gateway/infrastructure/jwt/JwtAuthorizationFilter.java
@@ -50,7 +50,7 @@ public class JwtAuthorizationFilter implements GlobalFilter, Ordered {
                 "/api/products", "/api/products/**",
                 "/api/orders", "/api/orders/**",
                 "/api/payments", "/api/payments/**",
-                "/api/waitingQueue/**", "/api/waitingRoom/**"
+                "/api/waitingQueue/**", "/api/waitingRoom/**", "/api/schedulingQueue/**"
                 );
 
         nonfilteredUrls = Arrays.asList("/api/auth/logIn","/api/auth/signUp", "/webjars", "/swagger-ui.html",
@@ -71,7 +71,8 @@ public class JwtAuthorizationFilter implements GlobalFilter, Ordered {
 
         sellerRules = new ArrayList<>();
         sellerRules.add(new AuthRule("/api/users", Set.of(HttpMethod.GET)));
-        sellerRules.add(new AuthRule("/api/waitingQueue/**", Set.of(HttpMethod.GET, HttpMethod.POST)));
+        customerRules.add(new AuthRule("/api/waitingQueue/{productId}/registerUser", Set.of(HttpMethod.POST)));
+        customerRules.add(new AuthRule("/api/waitingQueue/{productId}", Set.of(HttpMethod.GET)));
         sellerRules.add(new AuthRule("/api/waitingRoom/{productId}", Set.of(HttpMethod.GET)));
     }
 

--- a/gateway/src/main/java/com/j1p3ter/gateway/infrastructure/jwt/JwtAuthorizationFilter.java
+++ b/gateway/src/main/java/com/j1p3ter/gateway/infrastructure/jwt/JwtAuthorizationFilter.java
@@ -71,8 +71,8 @@ public class JwtAuthorizationFilter implements GlobalFilter, Ordered {
 
         sellerRules = new ArrayList<>();
         sellerRules.add(new AuthRule("/api/users", Set.of(HttpMethod.GET)));
-        customerRules.add(new AuthRule("/api/waitingQueue/{productId}/registerUser", Set.of(HttpMethod.POST)));
-        customerRules.add(new AuthRule("/api/waitingQueue/{productId}", Set.of(HttpMethod.GET)));
+        sellerRules.add(new AuthRule("/api/waitingQueue/{productId}/registerUser", Set.of(HttpMethod.POST)));
+        sellerRules.add(new AuthRule("/api/waitingQueue/{productId}", Set.of(HttpMethod.GET)));
         sellerRules.add(new AuthRule("/api/waitingRoom/{productId}", Set.of(HttpMethod.GET)));
     }
 

--- a/product-server/src/main/java/com/j1p3ter/productserver/application/client/QueueSchedulerClient.java
+++ b/product-server/src/main/java/com/j1p3ter/productserver/application/client/QueueSchedulerClient.java
@@ -1,0 +1,16 @@
+package com.j1p3ter.productserver.application.client;
+
+import com.j1p3ter.productserver.application.dto.scheduler.StartAllowRequestDto;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import reactor.core.publisher.Mono;
+
+@FeignClient(name = "queue-server")
+public interface QueueSchedulerClient {
+    @PostMapping("/api/schedulingQueue/{productId}/startAllow")
+    String startScheduling(@RequestHeader(name = "X-USER-ID") Long userId,
+                                        @PathVariable Long productId, @RequestBody StartAllowRequestDto requestDto);
+}

--- a/product-server/src/main/java/com/j1p3ter/productserver/application/dto/scheduler/StartAllowRequestDto.java
+++ b/product-server/src/main/java/com/j1p3ter/productserver/application/dto/scheduler/StartAllowRequestDto.java
@@ -1,0 +1,11 @@
+package com.j1p3ter.productserver.application.dto.scheduler;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class StartAllowRequestDto {
+    Long count;
+    Long delay;
+}

--- a/queue-server/src/main/java/com/j1p3ter/queueserver/QueueServerApplication.java
+++ b/queue-server/src/main/java/com/j1p3ter/queueserver/QueueServerApplication.java
@@ -14,6 +14,7 @@ import org.springframework.scheduling.annotation.EnableScheduling;
         }
 )
 @EnableDiscoveryClient
+@EnableScheduling
 @EnableFeignClients
 public class QueueServerApplication {
     public static void main(String[] args) {

--- a/queue-server/src/main/java/com/j1p3ter/queueserver/application/service/QueueService.java
+++ b/queue-server/src/main/java/com/j1p3ter/queueserver/application/service/QueueService.java
@@ -61,7 +61,7 @@ public class QueueService {
                 reactiveRedisTemplate.opsForZSet().popMin(QUEUE_WAIT_KEY.formatted(productId), count)
                         // pop한 값 proceed Queue에 추가
                         .flatMap(member -> reactiveRedisTemplate.opsForZSet().add(QUEUE_PROCEED_KEY.formatted(productId), member.getValue(), Instant.now().getEpochSecond()))
-                        .doOnNext(success -> log.info("User {} added to proceed queue", success))
+                        .doOnNext(success -> log.info("User " + success + " added to proceed queue"))
                         .count();
     }
 

--- a/queue-server/src/main/java/com/j1p3ter/queueserver/application/service/ScheduledQueueService.java
+++ b/queue-server/src/main/java/com/j1p3ter/queueserver/application/service/ScheduledQueueService.java
@@ -1,0 +1,25 @@
+package com.j1p3ter.queueserver.application.service;
+
+import com.j1p3ter.queueserver.config.QueueScheduler;
+import com.j1p3ter.queueserver.presentation.request.StartAllowRequestDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j(topic = "ScheduledQueue Service")
+public class ScheduledQueueService {
+    private final QueueScheduler queueScheduler;
+
+    public Mono<String> startScheduling(Long productId, StartAllowRequestDto requestDto) {
+        queueScheduler.scheduleTask(productId, requestDto.getCount(), requestDto.getDelay());
+        return Mono.just("스케줄링 시작 완료");
+    }
+
+    public Mono<String> stopScheduling(Long productId) {
+        queueScheduler.stopTask(productId);
+        return Mono.just("스케줄링 종료 완료");
+    }
+}

--- a/queue-server/src/main/java/com/j1p3ter/queueserver/config/QueueScheduler.java
+++ b/queue-server/src/main/java/com/j1p3ter/queueserver/config/QueueScheduler.java
@@ -2,11 +2,13 @@ package com.j1p3ter.queueserver.config;
 
 import com.j1p3ter.common.exception.ApiException;
 import com.j1p3ter.queueserver.application.client.ProductClient;
+import com.j1p3ter.queueserver.application.dto.RankResponseDto;
 import com.j1p3ter.queueserver.application.service.QueueService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -36,21 +38,33 @@ public class QueueScheduler {
     // 스케줄링 시 수행할 작업
     private Runnable getRunnable(Long productId,Long count) {
         return ()-> {
-            queueService.allowUser(productId,count);
+            queueService.allowUser(productId,count).subscribe();
+            // waiting 목록에 값이 없으면 스케줄링 종료
+            queueService.getWaitingUsers(productId)
+                    .flatMap(waitingCount -> {
+                        if (waitingCount == 0) {
+                            stopTask(productId);
+                        }
+                        return Mono.empty();
+                    }).subscribe();
         };
     }
 
     public void scheduleTask(Long productId, Long count, long delay) {
         // product에 지정된 startTime에 스케줄링 시작
         LocalDateTime startTime = productClient.getProduct(productId).getData().getSaleStartTime();
+
+        // 테스트 시에는 아래 시간으로 확인 가능 (바로 위 주석 처리 후 아래 주석 풀기)
+//        LocalDateTime startTime = LocalDateTime.now().plusMinutes(1);
+
         Runnable task = getRunnable(productId, count);
 
         ScheduledFuture<?> scheduledFuture = taskScheduler.schedule(task, triggerContext -> {
             if (triggerContext.lastCompletionTime() == null) { // 작업이 실행된 적 없을 경우
-                log.info(productId + " product : Scheduled to start at" + startTime);
+                log.info("product id " + productId + " / Scheduled to start at " + startTime);
                 return startTime.atZone(ZoneId.systemDefault()).toInstant();
             } else {
-                log.info( productId + " product : rescheduled with delay of " + delay + " ms");
+                log.info("product id " + productId + " / rescheduled with delay of " + delay + " ms");
                 return triggerContext.lastCompletionTime().toInstant().plusMillis(delay);
             }
         });
@@ -61,9 +75,10 @@ public class QueueScheduler {
         ScheduledFuture<?> future = scheduledTasks.get(productId);
         if (future != null) {
             future.cancel(true);
+            scheduledTasks.remove(productId); // 취소 후 제거
             log.info("Task for productId " + productId + " is stopped.");
         } else {
-            throw new ApiException(HttpStatus.BAD_REQUEST,"해당 product의 Task가 존재하지 않습니다.","No task found for productId " + productId);
+            throw new ApiException(HttpStatus.BAD_REQUEST, "해당 product의 Task가 존재하지 않습니다.", "No task found for productId " + productId);
         }
     }
 }

--- a/queue-server/src/main/java/com/j1p3ter/queueserver/config/QueueScheduler.java
+++ b/queue-server/src/main/java/com/j1p3ter/queueserver/config/QueueScheduler.java
@@ -53,8 +53,8 @@ public class QueueScheduler {
 
     public void scheduleTask(Long productId, Long count, long delay) {
         log.info("product id " + productId + " / Scheduled Allowed");
-        // product에 지정된 startTime에 스케줄링 시작
-        LocalDateTime startTime = productClient.getProduct(productId).getData().getSaleStartTime();
+        // product에 지정된 startTime 1분 뒤에 스케줄링 시작
+        LocalDateTime startTime = productClient.getProduct(productId).getData().getSaleStartTime().plusMinutes(1);
 
         // 테스트 시에는 아래 시간으로 확인 가능 (바로 위 주석 처리 후 아래 주석 풀기)
 //        LocalDateTime startTime = LocalDateTime.now().plusMinutes(1);

--- a/queue-server/src/main/java/com/j1p3ter/queueserver/config/QueueScheduler.java
+++ b/queue-server/src/main/java/com/j1p3ter/queueserver/config/QueueScheduler.java
@@ -10,6 +10,7 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Mono;
 
+import java.sql.Timestamp;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDateTime;
@@ -20,7 +21,7 @@ import java.util.Map;
 import java.util.concurrent.ScheduledFuture;
 
 @Component
-@Slf4j
+@Slf4j (topic = "Queue Scheduler")
 public class QueueScheduler {
     private final ThreadPoolTaskScheduler taskScheduler;
     // 스케줄링 작업의 상태를 나타내는 목록
@@ -51,6 +52,7 @@ public class QueueScheduler {
     }
 
     public void scheduleTask(Long productId, Long count, long delay) {
+        log.info("product id " + productId + " / Scheduled Allowed");
         // product에 지정된 startTime에 스케줄링 시작
         LocalDateTime startTime = productClient.getProduct(productId).getData().getSaleStartTime();
 
@@ -61,10 +63,10 @@ public class QueueScheduler {
 
         ScheduledFuture<?> scheduledFuture = taskScheduler.schedule(task, triggerContext -> {
             if (triggerContext.lastCompletionTime() == null) { // 작업이 실행된 적 없을 경우
-                log.info("product id " + productId + " / Scheduled to start at " + startTime);
+                log.info("product id " + productId + " : Scheduled to start at " + startTime);
                 return startTime.atZone(ZoneId.systemDefault()).toInstant();
             } else {
-                log.info("product id " + productId + " / rescheduled with delay of " + delay + " ms");
+                log.info("product id " + productId + " : rescheduled with delay of " + delay + " ms, TimeStamp : " + LocalDateTime.now());
                 return triggerContext.lastCompletionTime().toInstant().plusMillis(delay);
             }
         });

--- a/queue-server/src/main/java/com/j1p3ter/queueserver/config/QueueScheduler.java
+++ b/queue-server/src/main/java/com/j1p3ter/queueserver/config/QueueScheduler.java
@@ -1,0 +1,70 @@
+package com.j1p3ter.queueserver.config;
+
+import com.j1p3ter.common.exception.ApiException;
+import com.j1p3ter.queueserver.application.client.ProductClient;
+import com.j1p3ter.queueserver.application.service.QueueService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ScheduledFuture;
+
+@Component
+@Slf4j
+public class QueueScheduler {
+    private final ThreadPoolTaskScheduler taskScheduler;
+    // 스케줄링 작업의 상태를 나타내는 목록
+    private final Map<Long, ScheduledFuture<?>> scheduledTasks = new HashMap<>();
+    private final QueueService queueService;
+    private final ProductClient productClient;
+
+    public QueueScheduler(QueueService queueService, ProductClient productClient) {
+        this.queueService = queueService;
+        this.productClient = productClient;
+        this.taskScheduler = new ThreadPoolTaskScheduler();
+        this.taskScheduler.initialize();
+    }
+
+    // 스케줄링 시 수행할 작업
+    private Runnable getRunnable(Long productId,Long count) {
+        return ()-> {
+            queueService.allowUser(productId,count);
+        };
+    }
+
+    public void scheduleTask(Long productId, Long count, long delay) {
+        // product에 지정된 startTime에 스케줄링 시작
+        LocalDateTime startTime = productClient.getProduct(productId).getData().getSaleStartTime();
+        Runnable task = getRunnable(productId, count);
+
+        ScheduledFuture<?> scheduledFuture = taskScheduler.schedule(task, triggerContext -> {
+            if (triggerContext.lastCompletionTime() == null) { // 작업이 실행된 적 없을 경우
+                log.info(productId + " product : Scheduled to start at" + startTime);
+                return startTime.atZone(ZoneId.systemDefault()).toInstant();
+            } else {
+                log.info( productId + " product : rescheduled with delay of " + delay + " ms");
+                return triggerContext.lastCompletionTime().toInstant().plusMillis(delay);
+            }
+        });
+        scheduledTasks.put(productId, scheduledFuture); // 스케줄링 된 작업 저장
+    }
+
+    public void stopTask(Long productId) {
+        ScheduledFuture<?> future = scheduledTasks.get(productId);
+        if (future != null) {
+            future.cancel(true);
+            log.info("Task for productId " + productId + " is stopped.");
+        } else {
+            throw new ApiException(HttpStatus.BAD_REQUEST,"해당 product의 Task가 존재하지 않습니다.","No task found for productId " + productId);
+        }
+    }
+}
+

--- a/queue-server/src/main/java/com/j1p3ter/queueserver/presentation/controller/ScheduledQueueController.java
+++ b/queue-server/src/main/java/com/j1p3ter/queueserver/presentation/controller/ScheduledQueueController.java
@@ -1,0 +1,30 @@
+package com.j1p3ter.queueserver.presentation.controller;
+
+import com.j1p3ter.queueserver.application.service.ScheduledQueueService;
+import com.j1p3ter.queueserver.presentation.request.StartAllowRequestDto;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.*;
+import reactor.core.publisher.Mono;
+
+@RestController
+@AllArgsConstructor
+@RequestMapping("/api/schedulingQueue")
+@Slf4j(topic = "Scheduling Queue Controller")
+public class ScheduledQueueController {
+    private ScheduledQueueService scheduledQueueService;
+    @Operation(summary = "특정 productId의 allow 스케줄링 시작")
+    @PostMapping("/{productId}/startAllow")
+    public Mono<String> startScheduling(@RequestHeader(name = "X-USER-ID") Long userId,
+                                        @PathVariable Long productId, @RequestBody StartAllowRequestDto requestDto){
+        return scheduledQueueService.startScheduling(productId, requestDto);
+    }
+
+    @Operation(summary = "특정 productId의 allow 스케줄링 정지")
+    @PostMapping("/{productId}/stopAllow")
+    public Mono<String> stopScheduling(@RequestHeader(name = "X-USER-ID") Long userId,
+                                              @PathVariable Long productId){
+        return scheduledQueueService.stopScheduling(productId);
+    }
+}

--- a/queue-server/src/main/java/com/j1p3ter/queueserver/presentation/request/StartAllowRequestDto.java
+++ b/queue-server/src/main/java/com/j1p3ter/queueserver/presentation/request/StartAllowRequestDto.java
@@ -1,0 +1,11 @@
+package com.j1p3ter.queueserver.presentation.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+public class StartAllowRequestDto {
+    Long count;
+    Long delay;
+}

--- a/queue-server/src/main/resources/application-test.yml
+++ b/queue-server/src/main/resources/application-test.yml
@@ -12,3 +12,6 @@ eureka:
   client:
     service-url:
       defaultZone: http://localhost:8761/eureka/
+
+scheduler:
+  enabled: false

--- a/queue-server/src/main/resources/application.yml
+++ b/queue-server/src/main/resources/application.yml
@@ -28,3 +28,6 @@ management:
       show-details: always
     prometheus:
       enabled: true
+
+  scheduler:
+    enabled: true


### PR DESCRIPTION
## 📌 Related Issue
> 이슈 번호를 기재 해주세요 (ex) #0)

- #12 

## 📢 Changes
> 변경 사항을 기재 해주세요

### startScheduling
- productId, count (접근 허용 인원수), delay (접근 허용 간격, ms 단위)를 입력받아 동적으로 스케줄링 시작
- 입력받은 productId 별로 별도로 스케줄링, product에 저장된 saleStartTime부터 스케줄링 시작

### stopScheduling
- 입력받은 productId의 스케줄링 종료

### createProduct
- product 생성 시 startScheduling 호출, 자동으로 product에 저장된 saleStartTime 1분 뒤부터 스케줄링 시작
- `createProduct Controller` 에서 호출하는 `startScheduling`의 매개변수를 수정하여 진입 인원, delay 타임 적절하게 수정 가능
- 현재 10초에 1명 씩 진입

## 📸 Test
> 테스트 결과를 공유 해주세요

| product 생성 시 시작 시간 스케줄링에 정상 등록
![image](https://github.com/user-attachments/assets/34f3dac9-bb29-4ea2-b239-d61fd8591eab)

| queue에 사용자 추가
![image](https://github.com/user-attachments/assets/ce6f759c-5a70-433b-8b4d-3c7f54271518)

| 시간에 맞게 스케줄링 정상 수행
![image](https://github.com/user-attachments/assets/20957577-5155-4313-966d-e5532acfba89)

>> 위 테스트는 수정 전, 수정 이후에는 startTime 1분 뒤부터 스케줄링 시행

## 📢 Check List
> 체크 리스트를 확인하고 완료되면 체크 해주세요

- [x] 테스트를 완료 하셨나요?
- [x] Source Branch & Target Branch 확인 하셨나요??
- [x] 코드 리뷰 요청을 하셨나요??

## 🚀 참고 자료
> 참고 자료가 있다면 첨부 해주세요

## TODO
